### PR TITLE
Add mini games to veterinary quiz app

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
     <div class="container">
         <button id="twoPlayer" class="two-player-btn">Two Player Mode</button>
+        <button id="miniGames" class="two-player-btn" style="right:140px;">Mini Games</button>
         <h1>Welcome, Pablo! What would you like to learn about today?</h1>
         <div id="categories" class="categories"></div>
         <div id="quiz" class="quiz hidden">
@@ -22,6 +23,35 @@
             <div id="p2" class="player-score"></div>
         </div>
         <div id="result" class="hidden"></div>
+        <div id="miniGameMenu" class="hidden">
+            <h2>Select a Mini Game</h2>
+            <button id="startFlea">Flea Flicker</button>
+            <button id="startMemory">Drug Match</button>
+            <button id="startSort">Symptom Sorter</button>
+        </div>
+
+        <div id="fleaGame" class="hidden">
+            <p id="fleaScore"></p>
+            <div class="flea-container"></div>
+            <button id="fleaBack">Back to Menu</button>
+        </div>
+
+        <div id="memoryGame" class="hidden">
+            <div id="memoryGrid" class="memory-grid"></div>
+            <button id="memoryBack">Back to Menu</button>
+        </div>
+
+        <div id="sortGame" class="hidden">
+            <div class="sort-wrapper">
+                <div id="symptomItems" class="items"></div>
+                <div class="drop-zones">
+                    <div id="catZone" class="drop-zone">Cat</div>
+                    <div id="dogZone" class="drop-zone">Dog</div>
+                </div>
+            </div>
+            <p id="sortResult"></p>
+            <button id="sortBack">Back to Menu</button>
+        </div>
         <p class="disclaimer">This quiz is for educational purposes only and does not replace professional veterinary advice.</p>
     </div>
     <script src="scripts.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -362,6 +362,24 @@ const twoPlayerBtn = document.getElementById('twoPlayer');
 const scoreboard = document.getElementById('scoreboard');
 const p1El = document.getElementById('p1');
 const p2El = document.getElementById('p2');
+const miniGamesBtn = document.getElementById('miniGames');
+const miniMenu = document.getElementById('miniGameMenu');
+const startFleaBtn = document.getElementById('startFlea');
+const startMemoryBtn = document.getElementById('startMemory');
+const startSortBtn = document.getElementById('startSort');
+const fleaGame = document.getElementById('fleaGame');
+const fleaContainer = fleaGame.querySelector('.flea-container');
+const memoryGame = document.getElementById('memoryGame');
+const sortGame = document.getElementById('sortGame');
+const fleaScoreEl = document.getElementById('fleaScore');
+const fleaBack = document.getElementById('fleaBack');
+const memoryGrid = document.getElementById('memoryGrid');
+const memoryBack = document.getElementById('memoryBack');
+const sortItems = document.getElementById('symptomItems');
+const catZone = document.getElementById('catZone');
+const dogZone = document.getElementById('dogZone');
+const sortBack = document.getElementById('sortBack');
+const sortResultEl = document.getElementById('sortResult');
 
 let currentQuestions = [];
 let currentIndex = 0;
@@ -374,6 +392,7 @@ let activePlayer = null;
 let buzzActive = false;
 let typingInterval = null;
 let currentQuestion = null;
+let draggedItem = null;
 
 function shuffle(array) {
     for (let i = array.length - 1; i > 0; i--) {
@@ -381,6 +400,18 @@ function shuffle(array) {
         [array[i], array[j]] = [array[j], array[i]];
     }
     return array;
+}
+
+function hideAllGames() {
+    miniMenu.classList.add('hidden');
+    fleaGame.classList.add('hidden');
+    memoryGame.classList.add('hidden');
+    sortGame.classList.add('hidden');
+}
+
+function showMenu() {
+    hideAllGames();
+    miniMenu.classList.remove('hidden');
 }
 
 function loadCategories() {
@@ -527,3 +558,132 @@ nextBtn.addEventListener('click', () => {
 });
 
 loadCategories();
+
+miniGamesBtn.addEventListener('click', () => {
+    categoryContainer.classList.add('hidden');
+    quizContainer.classList.add('hidden');
+    scoreboard.classList.add('hidden');
+    resultEl.classList.add('hidden');
+    showMenu();
+});
+
+fleaBack.addEventListener('click', showMenu);
+memoryBack.addEventListener('click', showMenu);
+sortBack.addEventListener('click', showMenu);
+
+startFleaBtn.addEventListener('click', startFleaGame);
+startMemoryBtn.addEventListener('click', startMemoryGame);
+startSortBtn.addEventListener('click', startSortGame);
+
+// Flea Flicker
+let fleaScore = 0;
+let fleaInterval;
+function startFleaGame() {
+    hideAllGames();
+    fleaGame.classList.remove('hidden');
+    fleaScore = 0;
+    fleaScoreEl.textContent = 'Score: 0';
+    fleaContainer.innerHTML = '';
+    spawnFlea();
+    fleaInterval = setInterval(spawnFlea, 800);
+    setTimeout(endFleaGame, 30000);
+}
+
+function spawnFlea() {
+    const flea = document.createElement('div');
+    flea.className = 'flea';
+    flea.style.left = Math.random() * 280 + 'px';
+    flea.style.top = Math.random() * 280 + 'px';
+    fleaContainer.appendChild(flea);
+    flea.addEventListener('click', () => {
+        flea.remove();
+        fleaScore++;
+        fleaScoreEl.textContent = 'Score: ' + fleaScore;
+    });
+    setTimeout(() => flea.remove(), 1500);
+}
+
+function endFleaGame() {
+    clearInterval(fleaInterval);
+    alert('Game over! You squashed ' + fleaScore + ' fleas.');
+    showMenu();
+}
+
+// Drug Match
+let memorySelection = [];
+function startMemoryGame() {
+    hideAllGames();
+    memoryGame.classList.remove('hidden');
+    memoryGrid.innerHTML = '';
+    memorySelection = [];
+    const pairs = ['Prednisone','Prednisone','Metronidazole','Metronidazole','Glargine','Glargine','Furosemide','Furosemide'];
+    shuffle(pairs).forEach(text => {
+        const card = document.createElement('div');
+        card.className = 'memory-card';
+        card.dataset.text = text;
+        card.addEventListener('click', () => flipCard(card));
+        memoryGrid.appendChild(card);
+    });
+}
+
+function flipCard(card) {
+    if (memorySelection.length === 2 || card.textContent) return;
+    card.textContent = card.dataset.text;
+    memorySelection.push(card);
+    if (memorySelection.length === 2) {
+        const [c1, c2] = memorySelection;
+        if (c1.dataset.text === c2.dataset.text) {
+            memorySelection = [];
+            if (!memoryGrid.querySelector('.memory-card:not(:empty)')) {
+                setTimeout(() => alert('Great job!'), 200);
+            }
+        } else {
+            setTimeout(() => {
+                c1.textContent = '';
+                c2.textContent = '';
+                memorySelection = [];
+            }, 800);
+        }
+    }
+}
+
+// Symptom Sorter
+function startSortGame() {
+    hideAllGames();
+    sortGame.classList.remove('hidden');
+    sortResultEl.textContent = '';
+    sortItems.innerHTML = '';
+    const items = [
+        {text:'Hyperthyroidism', type:'cat'},
+        {text:'Parvovirus', type:'dog'},
+        {text:'FIV', type:'cat'},
+        {text:'Heartworm', type:'dog'},
+        {text:'Diabetes Mellitus', type:'cat'},
+        {text:'Lyme Disease', type:'dog'}
+    ];
+    shuffle(items).forEach(it => {
+        const div = document.createElement('div');
+        div.className = 'item';
+        div.textContent = it.text;
+        div.draggable = true;
+        div.dataset.type = it.type;
+        div.addEventListener('dragstart', ev => {
+            draggedItem = div;
+            ev.dataTransfer.setData('text', it.type);
+        });
+        sortItems.appendChild(div);
+    });
+}
+
+[catZone, dogZone].forEach(zone => {
+    zone.addEventListener('dragover', e => e.preventDefault());
+    zone.addEventListener('drop', e => {
+        const type = e.dataTransfer.getData('text');
+        if (draggedItem) zone.appendChild(draggedItem);
+        if (zone.id.startsWith(type)) {
+            sortResultEl.textContent = 'Correct!';
+        } else {
+            sortResultEl.textContent = 'Oops, try again!';
+        }
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -88,3 +88,70 @@ body {
     font-size: 0.9rem;
     color: #666;
 }
+
+.memory-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 70px);
+    grid-gap: 10px;
+    justify-content: center;
+    margin-bottom: 10px;
+}
+
+.memory-card {
+    width: 70px;
+    height: 70px;
+    background: #fafafa;
+    border: 1px solid #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.drop-zones {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 10px;
+}
+
+.drop-zone {
+    width: 45%;
+    min-height: 120px;
+    border: 2px dashed #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.items {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 5px;
+}
+
+.item {
+    padding: 6px 10px;
+    background: #e0e0e0;
+    border-radius: 4px;
+    cursor: grab;
+    margin: 2px;
+}
+
+.flea-container {
+    position: relative;
+    width: 300px;
+    height: 300px;
+    border: 1px solid #ccc;
+    margin: 0 auto 10px auto;
+}
+
+.flea {
+    width: 20px;
+    height: 20px;
+    background: brown;
+    border-radius: 50%;
+    position: absolute;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add Mini Games button and sections for three simple games
- implement Flea Flicker, Drug Match, and Symptom Sorter games
- style memory grid, drop zones, and flea game

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b90b2021c832f8a9fcec442938798