### PR TITLE
Implement Doctor Mode mini-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div class="container">
         <button id="twoPlayer" class="two-player-btn">Two Player Mode</button>
         <button id="miniGames" class="two-player-btn" style="right:140px;">Mini Games</button>
+        <button id="doctorMode" class="two-player-btn" style="right:270px;">Doctor Mode</button>
         <h1>Welcome, Pablo! What would you like to learn about today?</h1>
         <div id="categories" class="categories"></div>
         <div id="quiz" class="quiz hidden">
@@ -51,6 +52,11 @@
             </div>
             <p id="sortResult"></p>
             <button id="sortBack">Back to Menu</button>
+        </div>
+        <div id="doctorScreen" class="hidden">
+            <p id="doctorText"></p>
+            <div id="doctorOptions"></div>
+            <button id="doctorNext" class="hidden">Next</button>
         </div>
         <p class="disclaimer">This quiz is for educational purposes only and does not replace professional veterinary advice.</p>
     </div>

--- a/scripts.js
+++ b/scripts.js
@@ -400,6 +400,11 @@ const catZone = document.getElementById('catZone');
 const dogZone = document.getElementById('dogZone');
 const sortBack = document.getElementById('sortBack');
 const sortResultEl = document.getElementById('sortResult');
+const doctorModeBtn = document.getElementById('doctorMode');
+const doctorScreen = document.getElementById('doctorScreen');
+const doctorText = document.getElementById('doctorText');
+const doctorOptions = document.getElementById('doctorOptions');
+const doctorNext = document.getElementById('doctorNext');
 
 let currentQuestions = [];
 let currentIndex = 0;
@@ -413,6 +418,14 @@ let buzzActive = false;
 let typingInterval = null;
 let currentQuestion = null;
 let draggedItem = null;
+let doctorEvents = [];
+let doctorIndex = 0;
+const petDatabase = [
+    {name:'Buddy', species:'dog', breed:'Golden Retriever', age:8, sex:'neutered male', disease:'hip dysplasia'},
+    {name:'Luna', species:'cat', breed:'Siamese', age:4, sex:'spayed female', disease:'asthma'},
+    {name:'Max', species:'dog', breed:'Miniature Schnauzer', age:6, sex:'neutered male', disease:'diabetes mellitus'},
+    {name:'Molly', species:'cat', breed:'Persian', age:5, sex:'spayed female', disease:'polycystic kidney disease'}
+];
 
 function shuffle(array) {
     for (let i = array.length - 1; i > 0; i--) {
@@ -707,3 +720,98 @@ function startSortGame() {
         }
     });
 });
+
+doctorModeBtn.addEventListener('click', startDoctorMode);
+
+function startDoctorMode() {
+    categoryContainer.classList.add('hidden');
+    quizContainer.classList.add('hidden');
+    scoreboard.classList.add('hidden');
+    resultEl.classList.add('hidden');
+    hideAllGames();
+    doctorScreen.classList.remove('hidden');
+    doctorIndex = 0;
+    doctorEvents = [appointmentEvent(), messageEvent(), staffEvent()];
+    showDoctorEvent();
+}
+
+function appointmentEvent() {
+    const pet = petDatabase[Math.floor(Math.random() * petDatabase.length)];
+    const consult = Math.random() < 0.5 ? 'new consult' : 'recheck';
+    return function() {
+        doctorText.textContent = `Technician brings ${pet.name}, a ${pet.age}-year-old ${pet.sex} ${pet.breed} ${pet.species} for a ${consult} regarding ${pet.disease}. Vitals look good. What do you do next?`;
+        doctorOptions.innerHTML = '';
+        const options = ['Run blood work', 'Adjust medication', 'Schedule follow up', 'Send home'];
+        options.forEach(opt => {
+            const btn = document.createElement('button');
+            btn.textContent = opt;
+            btn.addEventListener('click', () => {
+                doctorText.textContent = `${opt} noted. The owner thanks you. Feedback: great visit!`;
+                doctorOptions.innerHTML = '';
+                doctorNext.classList.remove('hidden');
+            });
+            doctorOptions.appendChild(btn);
+        });
+        doctorNext.classList.add('hidden');
+        doctorNext.textContent = 'Next Event';
+    };
+}
+
+function messageEvent() {
+    return function() {
+        doctorText.textContent = 'Message from Gorgina: "Client asks about refilling medication."';
+        doctorOptions.innerHTML = '';
+        ['Approve refill', 'Need exam first', 'Decline', 'Ask for more info'].forEach(opt => {
+            const btn = document.createElement('button');
+            btn.textContent = opt;
+            btn.addEventListener('click', () => {
+                doctorText.textContent = `You chose: ${opt}.`;
+                doctorOptions.innerHTML = '';
+                doctorNext.classList.remove('hidden');
+            });
+            doctorOptions.appendChild(btn);
+        });
+        doctorNext.classList.add('hidden');
+        doctorNext.textContent = 'Next Event';
+    };
+}
+
+function staffEvent() {
+    return function() {
+        doctorText.textContent = 'The staff invites you to play a quick game or doodle on the whiteboard.';
+        doctorOptions.innerHTML = '';
+        ['Play trivia', 'Draw a doodle', 'Chat', 'Go back to work'].forEach(opt => {
+            const btn = document.createElement('button');
+            btn.textContent = opt;
+            btn.addEventListener('click', () => {
+                doctorText.textContent = `You decide to ${opt.toLowerCase()}. Everyone has fun!`;
+                doctorOptions.innerHTML = '';
+                doctorNext.classList.remove('hidden');
+            });
+            doctorOptions.appendChild(btn);
+        });
+        doctorNext.classList.add('hidden');
+        doctorNext.textContent = 'Next Event';
+    };
+}
+
+function showDoctorEvent() {
+    if (doctorIndex >= doctorEvents.length) {
+        doctorText.textContent = 'Doctor mode complete. Great job!';
+        doctorOptions.innerHTML = '';
+        doctorNext.textContent = 'Quit';
+        doctorNext.classList.remove('hidden');
+        doctorNext.onclick = quitDoctorMode;
+        return;
+    }
+    doctorNext.onclick = () => {
+        doctorIndex++;
+        showDoctorEvent();
+    };
+    doctorEvents[doctorIndex]();
+}
+
+function quitDoctorMode() {
+    doctorScreen.classList.add('hidden');
+    categoryContainer.classList.remove('hidden');
+}

--- a/styles.css
+++ b/styles.css
@@ -155,3 +155,21 @@ body {
     position: absolute;
     cursor: pointer;
 }
+
+#doctorScreen {
+    margin-top: 20px;
+}
+
+#doctorOptions button {
+    display: block;
+    margin: 8px 0;
+    padding: 8px 12px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    background: #fafafa;
+    cursor: pointer;
+}
+
+#doctorOptions button:hover {
+    background: #e0e0e0;
+}


### PR DESCRIPTION
## Summary
- add `Doctor Mode` button to start the new mode
- create new container for Doctor Mode UI
- style the doctor interface
- implement Doctor Mode logic with appointment, message and staff events

## Testing
- `node --check scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_684ba6d2a080832fbe11254c796e456a