### PR TITLE
Add whiteboard drawing game

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div class="container">
         <button id="miniGames" class="two-player-btn" style="right:180px;">Mini Games</button>
         <button id="doctorMode" class="two-player-btn" style="right:310px;">Doctor Mode</button>
+        <button id="whiteboardBtn" class="two-player-btn" style="right:440px;">Draw on Whiteboard</button>
         <button id="themeToggle" class="two-player-btn" style="right:50px;">Toggle Theme</button>
         <h1>Welcome, Pablo! What would you like to learn about today?</h1>
         <div id="categories" class="categories"></div>
@@ -87,6 +88,22 @@
             <div id="riddleOptions"></div>
             <p id="riddleResult"></p>
             <button id="riddleBack">Back to Menu</button>
+        </div>
+        <div id="whiteboardGame" class="hidden">
+            <p id="drawTheme"></p>
+            <canvas id="whiteboardCanvas" width="600" height="400"></canvas>
+            <div class="board-tools">
+                <div id="colorPalette">
+                    <button class="color-choice" data-color="#000000" style="background:#000000;"></button>
+                    <button class="color-choice" data-color="#ff0000" style="background:#ff0000;"></button>
+                    <button class="color-choice" data-color="#00ff00" style="background:#00ff00;"></button>
+                    <button class="color-choice" data-color="#0000ff" style="background:#0000ff;"></button>
+                    <button class="color-choice" data-color="#ffff00" style="background:#ffff00;"></button>
+                </div>
+                <button id="eraserBtn">Eraser</button>
+                <button id="whiteboardSave">Save</button>
+                <button id="whiteboardBack">Back</button>
+            </div>
         </div>
         <div id="doctorScreen" class="hidden">
             <p id="doctorText"></p>

--- a/scripts.js
+++ b/scripts.js
@@ -429,6 +429,14 @@ const doctorText = document.getElementById('doctorText');
 const doctorOptions = document.getElementById('doctorOptions');
 const doctorNext = document.getElementById('doctorNext');
 const doctorQuit = document.getElementById('doctorQuit');
+const whiteboardBtn = document.getElementById('whiteboardBtn');
+const whiteboardGame = document.getElementById('whiteboardGame');
+const whiteboardCanvas = document.getElementById('whiteboardCanvas');
+const drawThemeEl = document.getElementById('drawTheme');
+const whiteboardBack = document.getElementById('whiteboardBack');
+const whiteboardSave = document.getElementById('whiteboardSave');
+const eraserBtn = document.getElementById('eraserBtn');
+const colorButtons = document.querySelectorAll('.color-choice');
 
 let currentQuestions = [];
 let currentIndex = 0;
@@ -706,6 +714,7 @@ function hideAllGames() {
     guessGame.classList.add('hidden');
     clickGame.classList.add('hidden');
     riddleGame.classList.add('hidden');
+    whiteboardGame.classList.add('hidden');
 }
 
 function showMenu() {
@@ -1382,3 +1391,75 @@ function quitDoctorMode() {
     doctorNext.classList.add('hidden');
     doctorQuit.classList.add('hidden');
 }
+
+whiteboardBtn.addEventListener('click', startWhiteboardGame);
+
+function startWhiteboardGame() {
+    categoryContainer.classList.add('hidden');
+    quizContainer.classList.add('hidden');
+    scoreboard.classList.add('hidden');
+    resultEl.classList.add('hidden');
+    hideAllGames();
+    whiteboardGame.classList.remove('hidden');
+    clearCanvas();
+    const themes = ['Muppets', 'Nature', 'Favorite Foods', 'Outer Space', 'Underwater', 'Superheroes'];
+    drawThemeEl.textContent = 'Theme: ' + themes[Math.floor(Math.random() * themes.length)];
+}
+
+function clearCanvas() {
+    const ctx = whiteboardCanvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, whiteboardCanvas.width, whiteboardCanvas.height);
+}
+
+let drawing = false;
+let currentColor = '#000000';
+const ctx = whiteboardCanvas.getContext('2d');
+ctx.lineCap = 'round';
+ctx.lineWidth = 3;
+
+whiteboardCanvas.addEventListener('mousedown', e => {
+    drawing = true;
+    ctx.beginPath();
+    const rect = whiteboardCanvas.getBoundingClientRect();
+    ctx.moveTo(e.clientX - rect.left, e.clientY - rect.top);
+});
+
+whiteboardCanvas.addEventListener('mousemove', e => {
+    if (!drawing) return;
+    const rect = whiteboardCanvas.getBoundingClientRect();
+    ctx.lineTo(e.clientX - rect.left, e.clientY - rect.top);
+    ctx.strokeStyle = currentColor;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(e.clientX - rect.left, e.clientY - rect.top);
+});
+
+window.addEventListener('mouseup', () => {
+    drawing = false;
+    ctx.beginPath();
+});
+
+colorButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+        currentColor = btn.dataset.color;
+        ctx.lineWidth = 3;
+    });
+});
+
+eraserBtn.addEventListener('click', () => {
+    currentColor = '#ffffff';
+    ctx.lineWidth = 20;
+});
+
+whiteboardSave.addEventListener('click', () => {
+    const link = document.createElement('a');
+    link.href = whiteboardCanvas.toDataURL('image/jpeg');
+    link.download = 'drawing.jpg';
+    link.click();
+});
+
+whiteboardBack.addEventListener('click', () => {
+    whiteboardGame.classList.add('hidden');
+    categoryContainer.classList.remove('hidden');
+});

--- a/styles.css
+++ b/styles.css
@@ -211,3 +211,23 @@ body.dark button {
 body.dark button:hover {
     background-color: #666;
 }
+
+#whiteboardCanvas {
+    border: 1px solid #ccc;
+    display: block;
+    margin: 0 auto 10px auto;
+    background: #fff;
+}
+
+.board-tools {
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.color-choice {
+    width: 24px;
+    height: 24px;
+    border: none;
+    margin: 0 2px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add **Draw on Whiteboard** button
- implement a simple drawing canvas with color palette and save option
- style the new whiteboard elements

## Testing
- `npx eslint scripts.js` *(fails: ESLint config missing)*
- `npx htmlhint index.html` *(fails: requires package install)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d2fe23c832fb6b4726464d5dcc3