### PR TITLE
Improve color picker clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
                     <button class="color-choice" data-color="#00ff00" style="background:#00ff00;"></button>
                     <button class="color-choice" data-color="#0000ff" style="background:#0000ff;"></button>
                     <button class="color-choice" data-color="#ffff00" style="background:#ffff00;"></button>
+                    <label for="colorPicker" class="picker-label">Custom</label>
                     <input type="color" id="colorPicker" value="#000000">
                 </div>
                 <button id="eraserBtn">Eraser</button>

--- a/styles.css
+++ b/styles.css
@@ -237,7 +237,16 @@ body.dark button:hover {
     width: 30px;
     height: 30px;
     padding: 0;
-    border: none;
+    border: 1px solid #666;
+    border-radius: 4px;
     margin-left: 5px;
     background: none;
+    cursor: pointer;
+}
+
+.picker-label {
+    margin-left: 6px;
+    margin-right: 2px;
+    font-size: 0.9rem;
+    vertical-align: middle;
 }


### PR DESCRIPTION
## Summary
- add label for the whiteboard color input
- style custom color input with border and pointer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cb3ba2108832fb669ab60ed09844c