### PR TITLE
Add shadows and controls to surgery 3d scene

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,3 @@
-This is a HTML5 quiz app for Vet IM
+This is a HTML5 quiz app for Vet IM.
+The project includes a lightweight 3D surgery training scene built with Three.js.
+Use the arrow keys to move and drag with the mouse to look around the operating room.


### PR DESCRIPTION
## Summary
- add OrbitControls to surgery3d
- enable shadows and add overhead lamp
- update intro text and readme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d34665c832fa494849e8f2757eb