### PR TITLE
Add interaction prompt for surgery 3D stations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
 This is a HTML5 quiz app for Vet IM.
 The project includes a lightweight 3D surgery training scene built with Three.js.
-Click the canvas to lock the cursor and use WASD or the on-screen joystick for touch devices to move. Drag the mouse or touch to look around the operating room.
+Click the canvas to lock the cursor and use WASD or the on-screen joystick for touch devices to move. Drag the mouse or touch to look around the operating room. Approach a station and press the `E` key to begin its quiz.

--- a/styles.css
+++ b/styles.css
@@ -317,6 +317,10 @@ body.dark button:hover {
     border-radius: 4px;
     cursor: pointer;
 }
+#interactPrompt {
+    margin-top: 8px;
+    font-weight: bold;
+}
 #surgeryNext:hover, #surgeryExit:hover {
     background-color: #0d47a1;
 }

--- a/surgery.html
+++ b/surgery.html
@@ -14,7 +14,8 @@
         <canvas id="surgeryCanvas"></canvas>
         <div id="joystick" class="hidden"><div class="stick"></div></div>
         <div id="surgeryUI">
-            <p class="instructions">Click the canvas to lock the cursor. Use WASD or the on-screen joystick to move, and drag the mouse to look around. Approach a station to start questions.</p>
+            <p class="instructions">Click the canvas to lock the cursor. Use WASD or the on-screen joystick to move, and drag the mouse to look around. Approach a station and press E to start questions.</p>
+            <p id="interactPrompt" class="hidden"></p>
             <p id="surgeryQuestion"></p>
             <div id="surgeryOptions"></div>
             <button id="surgeryNext" class="hidden">Next</button>

--- a/surgery3d.js
+++ b/surgery3d.js
@@ -1,6 +1,7 @@
 let scene, camera, renderer, animationId, controls;
 const stations = {};
 let currentStation = null;
+let nearStation = null;
 const keys = {};
 
 function initSurgeryScene(){
@@ -422,21 +423,41 @@ function animate(){
 
 function showIntro(){
   const qEl = document.getElementById('surgeryQuestion');
-  qEl.textContent = "Click the canvas to lock the cursor. Use WASD or the on-screen joystick to move, and drag the mouse to look around. Approach a station for questions.";
+  qEl.textContent = "Click the canvas to lock the cursor. Use WASD or the on-screen joystick to move, and drag the mouse to look around. Approach a station and press E to start questions.";
   document.getElementById('surgeryOptions').innerHTML = '';
   document.getElementById('surgeryNext').classList.add('hidden');
+  const promptEl = document.getElementById('interactPrompt');
+  if(promptEl) promptEl.classList.add('hidden');
 }
 
 function checkStations(){
   if(currentStation) return;
   const pos = camera.position;
+  let found = false;
   for(const key in stations){
     const st = stations[key];
     if(pos.distanceTo(st.mesh.position) < 1.5 && st.index < st.questions.length){
-      currentStation = st;
-      loadQuestion();
+      nearStation = st;
+      found = true;
+      const promptEl = document.getElementById('interactPrompt');
+      if(promptEl){
+        promptEl.textContent = 'Press E to start quiz';
+        promptEl.classList.remove('hidden');
+      }
+      if(keys['KeyE']){
+        keys['KeyE'] = false;
+        currentStation = st;
+        nearStation = null;
+        if(promptEl) promptEl.classList.add('hidden');
+        loadQuestion();
+      }
       break;
     }
+  }
+  if(!found && nearStation){
+    nearStation = null;
+    const promptEl = document.getElementById('interactPrompt');
+    if(promptEl) promptEl.classList.add('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- update instructions on approaching stations
- add interact prompt element and style
- require pressing **E** to begin quiz at a station

## Testing
- `node -c surgery3d.js`

------
https://chatgpt.com/codex/tasks/task_e_684fb70d24a0832f81eed93dd7056402