### PR TITLE
Improve joystick usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
             <div id="joystick" class="hidden"><div class="stick"></div></div>
             <div id="surgeryUI">
                 <p class="instructions">Click the canvas to lock the cursor. Use WASD or the on-screen joystick to move, and drag the mouse to look around. Approach a station to start questions.</p>
+                <p id="interactPrompt" class="hidden"></p>
                 <p id="surgeryQuestion"></p>
                 <div id="surgeryOptions"></div>
                 <button id="surgeryNext" class="hidden">Next</button>

--- a/styles.css
+++ b/styles.css
@@ -308,6 +308,10 @@ body.dark button:hover {
 #surgeryOptions button {
     margin: 4px;
 }
+#surgeryOptions {
+    max-height: 40vh;
+    overflow-y: auto;
+}
 #surgeryNext, #surgeryExit {
     margin-top: 8px;
     padding: 6px 10px;

--- a/surgery3d.js
+++ b/surgery3d.js
@@ -362,12 +362,14 @@ function onKeyUp(e){ keys[e.code] = false; }
 
 function setupJoystick(el){
   const stick = el.querySelector('.stick');
-  let startX = 0, startY = 0;
+  let startX = 0, startY = 0, startScroll = 0;
+  const optDiv = document.getElementById('surgeryOptions');
   const threshold = 20;
   el.addEventListener('touchstart', e=>{
     const t = e.touches[0];
     startX = t.clientX;
     startY = t.clientY;
+    if(optDiv) startScroll = optDiv.scrollTop;
     stick.style.transform = 'translate(0,0)';
     e.preventDefault();
   });
@@ -378,10 +380,14 @@ function setupJoystick(el){
     const angle = Math.atan2(dy, dx);
     const dist = Math.min(40, Math.hypot(dx, dy));
     stick.style.transform = `translate(${dist*Math.cos(angle)}px,${dist*Math.sin(angle)}px)`;
-    keys['ArrowLeft'] = dx < -threshold;
-    keys['ArrowRight'] = dx > threshold;
-    keys['ArrowUp'] = dy < -threshold;
-    keys['ArrowDown'] = dy > threshold;
+    if(currentStation && optDiv && optDiv.scrollHeight > optDiv.clientHeight){
+      optDiv.scrollTop = startScroll - dy;
+    }else{
+      keys['ArrowLeft'] = dx < -threshold;
+      keys['ArrowRight'] = dx > threshold;
+      keys['ArrowUp'] = dy < -threshold;
+      keys['ArrowDown'] = dy > threshold;
+    }
     e.preventDefault();
   });
   el.addEventListener('touchend', () => {
@@ -428,6 +434,8 @@ function showIntro(){
   document.getElementById('surgeryNext').classList.add('hidden');
   const promptEl = document.getElementById('interactPrompt');
   if(promptEl) promptEl.classList.add('hidden');
+  const instrEl = document.querySelector('#surgeryUI .instructions');
+  if(instrEl) instrEl.classList.add('hidden');
 }
 
 function checkStations(){


### PR DESCRIPTION
## Summary
- allow scrolling option list with joystick when a quiz is active
- hide static instruction paragraph when showing intro text
- show hint prompt on index page
- make options container scrollable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fcbb48e90832faaf6f6c5a32c0349